### PR TITLE
1. fix maven-shade-plugin组件包shade的问题。由于io.netty.util.internal.NativeL…

### DIFF
--- a/cat-client/pom.xml
+++ b/cat-client/pom.xml
@@ -57,10 +57,14 @@
                      <shadeSourcesContent>true</shadeSourcesContent>
                      <minimizeJar>true</minimizeJar>
                      <relocations>
-                       <relocation>
-                         <pattern>io.netty</pattern>
-                         <shadedPattern>com.dianping.cat.netty</shadedPattern>
-                       </relocation>
+                        <relocation>
+                           <pattern>io.netty</pattern>
+                           <shadedPattern>com.dianping.cat.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>META-INF/native/libnetty</pattern>
+                           <shadedPattern>META-INF/native/libcom_dianping_cat_netty</shadedPattern>
+                        </relocation>
                      </relocations>
                   </configuration>
                </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
-				<version>4.1.42.Final</version>
+				<version>4.1.50.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
…ibraryLoader.calculatePackagePrefix的限制，shade完成后的目录不变，所以需要使用 com.dianping.cat.io.netty 才可以

2. 需要重命名META-INF/native/libnetty开头的所有文件为META-INF/native/libcom_dianping_cat_netty开头，防止加载失败的问题
3. 升级netty-all版本为4.1.50.Final，该版本首先支持AARCH64的原生epoll传输